### PR TITLE
Change Quarto setup to use conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ The documentation is written using `Quarto`.
 Download the latest version of `Quarto` from [here](https://quarto.org/) and then spin it up in development using
 
 ```bash
-python3 -m venv env
-source env/bin/activate
-pip3 install -r requirements.txt
+conda env create -f environment.yml
+conda activate frontiers-emulator-env
 export PYTHONPATH=$PYTHONPATH:`pwd`
 quarto preview docs
 ```


### PR DESCRIPTION
Alternatively you could ship `requirements.txt` if you wanted to not have `conda` as a dependency and use the `venv` sample that was originally in the README. Running locally it probably doesn't matter much.